### PR TITLE
fix test cases for log4shell

### DIFF
--- a/analytics/log4shell/unlog4shell.py
+++ b/analytics/log4shell/unlog4shell.py
@@ -89,14 +89,12 @@ class _TranslateTree(Transformer):
         return ("cstr", ''.join(args))
 
     def default(self, args):
-        if args:
-            return ("default", ''.join(args))
-        return ''
+        return ("default", ''.join(args))
 
     def prefix(self, args):
         if args and args[0]:
             return ("prefix", args[0].value)
-        return ''
+        return ("prefix", "")
 
 
 parser = Lark(grammar, parser='lalr', # debug=True,


### PR DESCRIPTION
the problem comes when multiple `cstr` gives results and assembles a `prefix` then. Need recursive parsing.

not the most elegant fix, but works. I first wanted to call a parser again but this is a simpler solution (manually parse the `subst`.

two questions to further improve:
1. what should be the evaluated results for this? `${lower:DC8m:-n}` (both runable prefix and default exist)
2. can we improve the syntax to differentiate the first prefix and following prefix in `${lower:lijsdf:38d:vmm}` so `lower` is recognized as a prefix but `lijsdf:38d:vmm` will be the value?